### PR TITLE
feat: add theme folder for static asset reference in js and css

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "types": ["vite/client"]
+  }
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -10,25 +10,24 @@
 // on production everything will work just fine
 
 //import vue from '@vitejs/plugin-vue'
-import { defineConfig } from 'vite'
-import liveReload from 'vite-plugin-live-reload'
-const { resolve } = require('path')
-const fs = require('fs')
-
+import { defineConfig } from 'vite';
+import liveReload from 'vite-plugin-live-reload';
+const { resolve } = require('path');
+const fs = require('fs');
 
 // https://vitejs.dev/config
 export default defineConfig({
-
   plugins: [
     //vue(),
-    liveReload(__dirname+'/**/*.php')
+    liveReload(__dirname + '/**/*.php'),
   ],
 
   // config
   root: '',
-  base: process.env.NODE_ENV === 'development'
-    ? '/'
-    : '/dist/',
+  base:
+    process.env.NODE_ENV === 'development'
+      ? `/wp-content/themes/${basename(__dirname)}/`
+      : `/wp-content/themes/${basename(__dirname)}/dist/`,
 
   build: {
     // output dir for production build
@@ -44,9 +43,9 @@ export default defineConfig({
     // our entry
     rollupOptions: {
       input: {
-        main: resolve( __dirname + '/main.js')
+        main: resolve(__dirname + '/main.js'),
       },
-      
+
       /*
       output: {
           entryFileNames: `[name].js`,
@@ -57,11 +56,10 @@ export default defineConfig({
 
     // minifying switch
     minify: true,
-    write: true
+    write: true,
   },
 
   server: {
-
     // required to load scripts from custom host
     cors: true,
 
@@ -90,7 +88,6 @@ export default defineConfig({
       host: 'localhost',
       //port: 443
     },
-    
   },
 
   // required for in-browser template compilation
@@ -98,7 +95,6 @@ export default defineConfig({
   resolve: {
     alias: {
       //vue: 'vue/dist/vue.esm-bundler.js'
-    }
-  }
-})
-
+    },
+  },
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -12,7 +12,7 @@
 //import vue from '@vitejs/plugin-vue'
 import { defineConfig } from 'vite';
 import liveReload from 'vite-plugin-live-reload';
-const { resolve } = require('path');
+const { resolve, basename } = require('path');
 const fs = require('fs');
 
 // https://vitejs.dev/config

--- a/vite.config.js
+++ b/vite.config.js
@@ -10,18 +10,16 @@
 // on production everything will work just fine
 
 //import vue from '@vitejs/plugin-vue'
-import { defineConfig } from 'vite'
-import liveReload from 'vite-plugin-live-reload'
-const { resolve, basename } = require('path')
-const fs = require('fs')
-
+import { defineConfig } from 'vite';
+import liveReload from 'vite-plugin-live-reload';
+const { resolve, basename } = require('path');
+const fs = require('fs');
 
 // https://vitejs.dev/config
 export default defineConfig({
-
   plugins: [
     //vue(),
-    liveReload(__dirname+'/**/*.php')
+    liveReload(__dirname + '/**/*.php'),
   ],
 
   // config
@@ -45,9 +43,9 @@ export default defineConfig({
     // our entry
     rollupOptions: {
       input: {
-        main: resolve( __dirname + '/main.js')
+        main: resolve(__dirname + '/main.js'),
       },
-      
+
       /*
       output: {
           entryFileNames: `[name].js`,
@@ -58,11 +56,10 @@ export default defineConfig({
 
     // minifying switch
     minify: true,
-    write: true
+    write: true,
   },
 
   server: {
-
     // required to load scripts from custom host
     cors: true,
 
@@ -91,7 +88,6 @@ export default defineConfig({
       host: 'localhost',
       //port: 443
     },
-    
   },
 
   // required for in-browser template compilation
@@ -99,7 +95,7 @@ export default defineConfig({
   resolve: {
     alias: {
       //vue: 'vue/dist/vue.esm-bundler.js'
-    }
-  }
-})
-
+      assets: '/assets',
+    },
+  },
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -10,16 +10,18 @@
 // on production everything will work just fine
 
 //import vue from '@vitejs/plugin-vue'
-import { defineConfig } from 'vite';
-import liveReload from 'vite-plugin-live-reload';
-const { resolve, basename } = require('path');
-const fs = require('fs');
+import { defineConfig } from 'vite'
+import liveReload from 'vite-plugin-live-reload'
+const { resolve, basename } = require('path')
+const fs = require('fs')
+
 
 // https://vitejs.dev/config
 export default defineConfig({
+
   plugins: [
     //vue(),
-    liveReload(__dirname + '/**/*.php'),
+    liveReload(__dirname+'/**/*.php')
   ],
 
   // config
@@ -43,9 +45,9 @@ export default defineConfig({
     // our entry
     rollupOptions: {
       input: {
-        main: resolve(__dirname + '/main.js'),
+        main: resolve( __dirname + '/main.js')
       },
-
+      
       /*
       output: {
           entryFileNames: `[name].js`,
@@ -56,10 +58,11 @@ export default defineConfig({
 
     // minifying switch
     minify: true,
-    write: true,
+    write: true
   },
 
   server: {
+
     // required to load scripts from custom host
     cors: true,
 
@@ -88,6 +91,7 @@ export default defineConfig({
       host: 'localhost',
       //port: 443
     },
+    
   },
 
   // required for in-browser template compilation
@@ -95,6 +99,7 @@ export default defineConfig({
   resolve: {
     alias: {
       //vue: 'vue/dist/vue.esm-bundler.js'
-    },
-  },
-});
+    }
+  }
+})
+


### PR DESCRIPTION
My problem was that I couldn't use static assets in javascript, because it referenced to `/assets`.
I added functionality so that it references to `/wp-content/themes/[THEME-NAME]/assets/`
Also, for CSS @import I added an alias, so that 'assets' always refers to the assets folder in your theme, instead of the root of the site (which doesn't exist)

Added two things:
1. A prefix for static assets
2. Added an alias to support css @import 
3. Added a tsconfig file with typescript support for this as well, else you will get ts errors if you reference to static assets